### PR TITLE
mf - create database table for UCSBDiningCommonsMenuItem

### DIFF
--- a/src/main/java/edu/ucsb/cs156/example/entities/UCSBDiningCommonsMenuItem.java
+++ b/src/main/java/edu/ucsb/cs156/example/entities/UCSBDiningCommonsMenuItem.java
@@ -1,0 +1,21 @@
+package edu.ucsb.cs156.example.entities;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/** This is a JPA entity that represents a UCSBDiningCommonsMenuItem */
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+@Entity(name = "ucsbdiningcommonsmenuitems")
+public class UCSBDiningCommonsMenuItem {
+  @Id private Long code;
+  private String diningCommonsCode;
+  private String name;
+  private String station;
+}

--- a/src/main/java/edu/ucsb/cs156/example/entities/UCSBDiningCommonsMenuItem.java
+++ b/src/main/java/edu/ucsb/cs156/example/entities/UCSBDiningCommonsMenuItem.java
@@ -14,7 +14,7 @@ import lombok.NoArgsConstructor;
 @Builder
 @Entity(name = "ucsbdiningcommonsmenuitems")
 public class UCSBDiningCommonsMenuItem {
-  @Id private Long code;
+  @Id private Long id;
   private String diningCommonsCode;
   private String name;
   private String station;

--- a/src/main/java/edu/ucsb/cs156/example/repositories/UCSBDiningCommonsMenuItemRepository.java
+++ b/src/main/java/edu/ucsb/cs156/example/repositories/UCSBDiningCommonsMenuItemRepository.java
@@ -1,0 +1,12 @@
+package edu.ucsb.cs156.example.repositories;
+
+import edu.ucsb.cs156.example.entities.UCSBDiningCommonsMenuItem;
+import org.springframework.data.repository.CrudRepository;
+import org.springframework.data.rest.core.annotation.RepositoryRestResource;
+import org.springframework.stereotype.Repository;
+
+/** The UCSBDiningCommonsRepository is a repository for UCSBDiningCommons entities */
+@Repository
+@RepositoryRestResource(exported = false)
+public interface UCSBDiningCommonsMenuItemRepository
+    extends CrudRepository<UCSBDiningCommonsMenuItem, Long> {}

--- a/src/main/resources/db/migration/changes/UCSBDiningCommonsMenuItem.json
+++ b/src/main/resources/db/migration/changes/UCSBDiningCommonsMenuItem.json
@@ -11,7 +11,7 @@
               "not": [
                 {
                   "tableExists": {
-                    "tableName": "UCSBDININGCOMMONMENUITEMS"
+                    "tableName": "UCSBDININGCOMMONSMENUITEMS"
                   }
                 }
               ]
@@ -25,15 +25,15 @@
                     "column": {
                       "constraints": {
                         "primaryKey": true,
-                        "primaryKeyName": "DININGCOMMONMENUITEMS_PK"
+                        "primaryKeyName": "DININGCOMMONSMENUITEMS_PK"
                       },
                       "name": "ID",
-                      "type": "LONG"
+                      "type": "BIGINT"
                     }
                   },
                   {
                     "column": {
-                      "name": "DININGCOMMONSCODE",
+                      "name": "DINING_COMMONS_CODE",
                       "type": "VARCHAR(255)"
                     }
                   },
@@ -48,9 +48,9 @@
                       "name": "STATION",
                       "type": "VARCHAR(255)"
                     }
-                  }]
-                ,
-                "tableName": "UCSBDININGCOMMONMENUITEMS"
+                  }
+                ],
+                "tableName": "UCSBDININGCOMMONSMENUITEMS"
               }
             }]
 

--- a/src/main/resources/db/migration/changes/UCSBDiningCommonsMenuItem.json
+++ b/src/main/resources/db/migration/changes/UCSBDiningCommonsMenuItem.json
@@ -1,0 +1,59 @@
+{ "databaseChangeLog": [
+    {
+        "changeSet": {
+          "id": "UCSBDiningCommonsMenuItem-1",
+          "author": "mikaelafitz",
+          "preConditions": [
+            {
+              "onFail": "MARK_RAN"
+            },
+            {
+              "not": [
+                {
+                  "tableExists": {
+                    "tableName": "UCSBDININGCOMMONMENUITEMS"
+                  }
+                }
+              ]
+            }
+          ],
+          "changes": [
+            {
+              "createTable": {
+                "columns": [
+                  {
+                    "column": {
+                      "constraints": {
+                        "primaryKey": true,
+                        "primaryKeyName": "DININGCOMMONMENUITEMS_PK"
+                      },
+                      "name": "CODE",
+                      "type": "LONG"
+                    }
+                  },
+                  {
+                    "column": {
+                      "name": "DININGCOMMONSCODE",
+                      "type": "VARCHAR(255)"
+                    }
+                  },
+                  {
+                    "column": {
+                      "name": "NAME",
+                      "type": "VARCHAR(255)"
+                    }
+                  },
+                  {
+                    "column": {
+                      "name": "STATION",
+                      "type": "VARCHAR(255)"
+                    }
+                  }]
+                ,
+                "tableName": "UCSBDININGCOMMONMENUITEMS"
+              }
+            }]
+
+        }
+    }
+]}

--- a/src/main/resources/db/migration/changes/UCSBDiningCommonsMenuItem.json
+++ b/src/main/resources/db/migration/changes/UCSBDiningCommonsMenuItem.json
@@ -27,7 +27,7 @@
                         "primaryKey": true,
                         "primaryKeyName": "DININGCOMMONMENUITEMS_PK"
                       },
-                      "name": "CODE",
+                      "name": "ID",
                       "type": "LONG"
                     }
                   },


### PR DESCRIPTION
Closes #8 

In this PR, we add a database table that represents the UCSB dining commons menu items, with the following fields:

```
BigInt id;
String diningCommonsCode;
String name;
String station;
```
You can test this by running on localhost and looking for the UCSBDiningCommonsMenuItems table in the h2-console

<img width="317" height="154" alt="image" src="https://github.com/user-attachments/assets/dc35cffa-fd1c-4ff0-951c-fabf2c918fae" />


You can also test this by running on dokku and connecting to the postgres database and running \dt:

<img width="629" height="318" alt="image" src="https://github.com/user-attachments/assets/1452aca9-2fe4-4d39-8a90-117d0f5381d8" />
