### PR TITLE
xuanbo put for article table

### DIFF
--- a/src/main/java/edu/ucsb/cs156/example/controllers/ArticlesController.java
+++ b/src/main/java/edu/ucsb/cs156/example/controllers/ArticlesController.java
@@ -6,7 +6,6 @@ import edu.ucsb.cs156.example.errors.EntityNotFoundException;
 import edu.ucsb.cs156.example.repositories.ArticlesRepository;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
-import io.swagger.v3.oas.annotations.parameters.RequestBody;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import java.time.ZonedDateTime;
@@ -110,7 +109,8 @@ class ArticlesController extends ApiController {
   @PreAuthorize("hasRole('ROLE_ADMIN')")
   @PutMapping("")
   public Articles updateArticle(
-      @Parameter(name = "id") @RequestParam Long id, @RequestBody @Valid Articles incoming) {
+      @Parameter(name = "id") @RequestParam Long id,
+      @org.springframework.web.bind.annotation.RequestBody @Valid Articles incoming) {
 
     Articles article =
         ArticlesRepository.findById(id)
@@ -122,8 +122,7 @@ class ArticlesController extends ApiController {
     article.setEmail(incoming.getEmail());
     article.setDateAdded(incoming.getDateAdded());
 
-    ArticlesRepository.save(article);
-
-    return article;
+    Articles savedArticle = ArticlesRepository.save(article);
+    return savedArticle;
   }
 }

--- a/src/main/java/edu/ucsb/cs156/example/controllers/ArticlesController.java
+++ b/src/main/java/edu/ucsb/cs156/example/controllers/ArticlesController.java
@@ -6,7 +6,9 @@ import edu.ucsb.cs156.example.errors.EntityNotFoundException;
 import edu.ucsb.cs156.example.repositories.ArticlesRepository;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.parameters.RequestBody;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import java.time.ZonedDateTime;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -14,6 +16,7 @@ import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -92,6 +95,34 @@ class ArticlesController extends ApiController {
     Articles article =
         ArticlesRepository.findById(id)
             .orElseThrow(() -> new EntityNotFoundException(Articles.class, id));
+
+    return article;
+  }
+
+  /**
+   * Update a single article
+   *
+   * @param id id of the article to update
+   * @param incoming the new article
+   * @return the updated article object
+   */
+  @Operation(summary = "Update a single article")
+  @PreAuthorize("hasRole('ROLE_ADMIN')")
+  @PutMapping("")
+  public Articles updateArticle(
+      @Parameter(name = "id") @RequestParam Long id, @RequestBody @Valid Articles incoming) {
+
+    Articles article =
+        ArticlesRepository.findById(id)
+            .orElseThrow(() -> new EntityNotFoundException(Articles.class, id));
+
+    article.setTitle(incoming.getTitle());
+    article.setUrl(incoming.getUrl());
+    article.setExplanation(incoming.getExplanation());
+    article.setEmail(incoming.getEmail());
+    article.setDateAdded(incoming.getDateAdded());
+
+    ArticlesRepository.save(article);
 
     return article;
   }

--- a/src/test/java/edu/ucsb/cs156/example/controllers/ArticlesControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/example/controllers/ArticlesControllerTests.java
@@ -225,7 +225,7 @@ public class ArticlesControllerTests extends ControllerTestCase {
     String requestBody = mapper.writeValueAsString(editedArticle);
 
     when(articlesRepository.findById(eq(67L))).thenReturn(Optional.of(article1));
-    when(articlesRepository.save(article1)).thenReturn(editedArticle);
+    when(articlesRepository.save(article1)).thenAnswer(invocation -> invocation.getArgument(0));
     // act
     MvcResult response =
         mockMvc

--- a/src/test/java/edu/ucsb/cs156/example/controllers/ArticlesControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/example/controllers/ArticlesControllerTests.java
@@ -218,7 +218,7 @@ public class ArticlesControllerTests extends ControllerTestCase {
             .title("To be")
             .url(
                 "https://docs.google.com/presentation/d/1BTg6PEWBjqGG7nBHlcOk1WL7SDR4TywB-SPjUVFyZmY/edit?slide=id.p13#slide=id.p13")
-            .explanation("aa")
+            .explanation("aaa")
             .email("zhao@ucsb.edu")
             .dateAdded(zdt2)
             .build();
@@ -243,7 +243,7 @@ public class ArticlesControllerTests extends ControllerTestCase {
                 jsonPath("$.url")
                     .value(
                         "https://docs.google.com/presentation/d/1BTg6PEWBjqGG7nBHlcOk1WL7SDR4TywB-SPjUVFyZmY/edit?slide=id.p13#slide=id.p13"))
-            .andExpect(jsonPath("$.explanation").value("aa"))
+            .andExpect(jsonPath("$.explanation").value("aaa"))
             .andExpect(jsonPath("$.email").value("zhao@ucsb.edu"))
             .andExpect(jsonPath("$.dateAdded").value("2026-04-14T19:07:18.613Z"))
             .andReturn();
@@ -257,7 +257,7 @@ public class ArticlesControllerTests extends ControllerTestCase {
     assertEquals(
         "https://docs.google.com/presentation/d/1BTg6PEWBjqGG7nBHlcOk1WL7SDR4TywB-SPjUVFyZmY/edit?slide=id.p13#slide=id.p13",
         article1.getUrl());
-    assertEquals("aa", article1.getExplanation());
+    assertEquals("aaa", article1.getExplanation());
     assertEquals("zhao@ucsb.edu", article1.getEmail());
     assertEquals(zdt2, article1.getDateAdded());
 

--- a/src/test/java/edu/ucsb/cs156/example/controllers/ArticlesControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/example/controllers/ArticlesControllerTests.java
@@ -22,6 +22,7 @@ import java.util.Optional;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MvcResult;
@@ -191,5 +192,96 @@ public class ArticlesControllerTests extends ControllerTestCase {
     String expectedJson = mapper.writeValueAsString(article1);
     String responseString = response.getResponse().getContentAsString();
     assertEquals(expectedJson, responseString);
+  }
+
+  @WithMockUser(roles = {"ADMIN", "USER"})
+  @Test
+  public void admin_can_edit_an_existing_article() throws Exception {
+    // arrange
+
+    ZonedDateTime zdt1 = ZonedDateTime.parse("2026-04-24T19:07:18.613Z");
+    ZonedDateTime zdt2 = ZonedDateTime.parse("2026-04-14T19:07:18.613Z");
+
+    Articles article1 =
+        Articles.builder()
+            .title("To be or not To be")
+            .url("https://www.amazon.com/hz/mobile")
+            .explanation("aa")
+            .email("xuanbo@ucsb.edu")
+            .dateAdded(zdt1)
+            .build();
+
+    Articles editedArticle =
+        Articles.builder()
+            .id(67L)
+            .title("To be ")
+            .url(
+                "https://docs.google.com/presentation/d/1BTg6PEWBjqGG7nBHlcOk1WL7SDR4TywB-SPjUVFyZmY/edit?slide=id.p13#slide=id.p13")
+            .explanation("aa")
+            .email("zhao@ucsb.edu")
+            .dateAdded(zdt2)
+            .build();
+
+    String requestBody = mapper.writeValueAsString(editedArticle);
+
+    when(articlesRepository.findById(eq(67L))).thenReturn(Optional.of(article1));
+    when(articlesRepository.save(article1)).thenReturn(editedArticle);
+    // act
+    MvcResult response =
+        mockMvc
+            .perform(
+                put("/api/articles")
+                    .param("id", "67")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .characterEncoding("utf-8")
+                    .content(requestBody)
+                    .with(csrf()))
+            .andExpect(status().isOk())
+            .andReturn();
+
+    // assert
+    verify(articlesRepository, times(1)).findById(67L);
+    verify(articlesRepository, times(1)).save(article1);
+    String responseString = response.getResponse().getContentAsString();
+    assertEquals(requestBody, responseString);
+  }
+
+  @WithMockUser(roles = {"ADMIN", "USER"})
+  @Test
+  public void admin_cannot_edit_ucsbdate_that_does_not_exist() throws Exception {
+    // arrange
+
+    ZonedDateTime zdt1 = ZonedDateTime.parse("2026-04-24T19:07:18.613Z");
+
+    Articles article1 =
+        Articles.builder()
+            .title("To be or not To be")
+            .url("https://www.amazon.com/hz/mobile")
+            .explanation("aa")
+            .email("xuanbo@ucsb.edu")
+            .dateAdded(zdt1)
+            .build();
+
+    String requestBody = mapper.writeValueAsString(article1);
+
+    when(articlesRepository.findById(eq(67L))).thenReturn(Optional.empty());
+
+    // act
+    MvcResult response =
+        mockMvc
+            .perform(
+                put("/api/articles")
+                    .param("id", "67")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .characterEncoding("utf-8")
+                    .content(requestBody)
+                    .with(csrf()))
+            .andExpect(status().isNotFound())
+            .andReturn();
+
+    // assert
+    verify(articlesRepository, times(1)).findById(67L);
+    Map<String, Object> json = responseToJson(response);
+    assertEquals("Articles with id 67 not found", json.get("message"));
   }
 }

--- a/src/test/java/edu/ucsb/cs156/example/controllers/ArticlesControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/example/controllers/ArticlesControllerTests.java
@@ -204,6 +204,7 @@ public class ArticlesControllerTests extends ControllerTestCase {
 
     Articles article1 =
         Articles.builder()
+            .id(67L)
             .title("To be or not To be")
             .url("https://www.amazon.com/hz/mobile")
             .explanation("aa")
@@ -250,6 +251,16 @@ public class ArticlesControllerTests extends ControllerTestCase {
     // assert
     verify(articlesRepository, times(1)).findById(67L);
     verify(articlesRepository, times(1)).save(article1);
+
+    // ✅ Add these to kill the surviving mutations
+    assertEquals("To be", article1.getTitle());
+    assertEquals(
+        "https://docs.google.com/presentation/d/1BTg6PEWBjqGG7nBHlcOk1WL7SDR4TywB-SPjUVFyZmY/edit?slide=id.p13#slide=id.p13",
+        article1.getUrl());
+    assertEquals("aa", article1.getExplanation());
+    assertEquals("zhao@ucsb.edu", article1.getEmail());
+    assertEquals(zdt2, article1.getDateAdded());
+
     String responseString = response.getResponse().getContentAsString();
     assertEquals(requestBody, responseString);
   }

--- a/src/test/java/edu/ucsb/cs156/example/controllers/ArticlesControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/example/controllers/ArticlesControllerTests.java
@@ -214,7 +214,7 @@ public class ArticlesControllerTests extends ControllerTestCase {
     Articles editedArticle =
         Articles.builder()
             .id(67L)
-            .title("To be ")
+            .title("To be")
             .url(
                 "https://docs.google.com/presentation/d/1BTg6PEWBjqGG7nBHlcOk1WL7SDR4TywB-SPjUVFyZmY/edit?slide=id.p13#slide=id.p13")
             .explanation("aa")
@@ -237,6 +237,14 @@ public class ArticlesControllerTests extends ControllerTestCase {
                     .content(requestBody)
                     .with(csrf()))
             .andExpect(status().isOk())
+            .andExpect(jsonPath("$.title").value("To be"))
+            .andExpect(
+                jsonPath("$.url")
+                    .value(
+                        "https://docs.google.com/presentation/d/1BTg6PEWBjqGG7nBHlcOk1WL7SDR4TywB-SPjUVFyZmY/edit?slide=id.p13#slide=id.p13"))
+            .andExpect(jsonPath("$.explanation").value("aa"))
+            .andExpect(jsonPath("$.email").value("zhao@ucsb.edu"))
+            .andExpect(jsonPath("$.dateAdded").value("2026-04-14T19:07:18.613Z"))
             .andReturn();
 
     // assert


### PR DESCRIPTION
Closes #41 
In this PR, we add PUT operations to the Articles Controller so we can edit existing articles.
<img width="1504" height="860" alt="Screenshot 2026-04-25 at 02 56 39" src="https://github.com/user-attachments/assets/cef17852-d1ed-46d3-94ae-fc901180c729" />
<img width="1456" height="667" alt="Screenshot 2026-04-25 at 02 57 54" src="https://github.com/user-attachments/assets/54d628bc-f325-4afb-b51f-2b6babe9ba33" />
<img width="1407" height="161" alt="Screenshot 2026-04-25 at 02 58 21" src="https://github.com/user-attachments/assets/e11d8c05-926e-4b5e-9e6f-c69c84248346" />
