### PR TITLE
Xuanbo delete for article table

### DIFF
--- a/src/main/java/edu/ucsb/cs156/example/controllers/ArticlesController.java
+++ b/src/main/java/edu/ucsb/cs156/example/controllers/ArticlesController.java
@@ -6,7 +6,6 @@ import edu.ucsb.cs156.example.errors.EntityNotFoundException;
 import edu.ucsb.cs156.example.repositories.ArticlesRepository;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
-import io.swagger.v3.oas.annotations.parameters.RequestBody;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import java.time.ZonedDateTime;
@@ -110,7 +109,8 @@ class ArticlesController extends ApiController {
   @PreAuthorize("hasRole('ROLE_ADMIN')")
   @PutMapping("")
   public Articles updateArticle(
-      @Parameter(name = "id") @RequestParam Long id, @RequestBody @Valid Articles incoming) {
+      @Parameter(name = "id") @RequestParam Long id,
+      @org.springframework.web.bind.annotation.RequestBody @Valid Articles incoming) {
 
     Articles article =
         ArticlesRepository.findById(id)
@@ -122,8 +122,7 @@ class ArticlesController extends ApiController {
     article.setEmail(incoming.getEmail());
     article.setDateAdded(incoming.getDateAdded());
 
-    ArticlesRepository.save(article);
-
-    return article;
+    Articles savedArticle = ArticlesRepository.save(article);
+    return savedArticle;
   }
 }

--- a/src/main/java/edu/ucsb/cs156/example/controllers/ArticlesController.java
+++ b/src/main/java/edu/ucsb/cs156/example/controllers/ArticlesController.java
@@ -13,6 +13,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
@@ -124,5 +125,23 @@ class ArticlesController extends ApiController {
 
     Articles savedArticle = ArticlesRepository.save(article);
     return savedArticle;
+  }
+
+  /**
+   * Delete a article
+   *
+   * @param id the id of the article to delete
+   * @return a message indicating the article was deleted
+   */
+  @Operation(summary = "Delete a article")
+  @PreAuthorize("hasRole('ROLE_ADMIN')")
+  @DeleteMapping("")
+  public Object deleteArticle(@Parameter(name = "id") @RequestParam Long id) {
+    Articles article =
+        ArticlesRepository.findById(id)
+            .orElseThrow(() -> new EntityNotFoundException(Articles.class, id));
+
+    ArticlesRepository.delete(article);
+    return genericMessage("Article with id %s deleted".formatted(id));
   }
 }

--- a/src/main/java/edu/ucsb/cs156/example/controllers/ArticlesController.java
+++ b/src/main/java/edu/ucsb/cs156/example/controllers/ArticlesController.java
@@ -6,7 +6,9 @@ import edu.ucsb.cs156.example.errors.EntityNotFoundException;
 import edu.ucsb.cs156.example.repositories.ArticlesRepository;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.parameters.RequestBody;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import java.time.ZonedDateTime;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -14,6 +16,7 @@ import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -92,6 +95,34 @@ class ArticlesController extends ApiController {
     Articles article =
         ArticlesRepository.findById(id)
             .orElseThrow(() -> new EntityNotFoundException(Articles.class, id));
+
+    return article;
+  }
+
+  /**
+   * Update a single article
+   *
+   * @param id id of the article to update
+   * @param incoming the new article
+   * @return the updated article object
+   */
+  @Operation(summary = "Update a single article")
+  @PreAuthorize("hasRole('ROLE_ADMIN')")
+  @PutMapping("")
+  public Articles updateArticle(
+      @Parameter(name = "id") @RequestParam Long id, @RequestBody @Valid Articles incoming) {
+
+    Articles article =
+        ArticlesRepository.findById(id)
+            .orElseThrow(() -> new EntityNotFoundException(Articles.class, id));
+
+    article.setTitle(incoming.getTitle());
+    article.setUrl(incoming.getUrl());
+    article.setExplanation(incoming.getExplanation());
+    article.setEmail(incoming.getEmail());
+    article.setDateAdded(incoming.getDateAdded());
+
+    ArticlesRepository.save(article);
 
     return article;
   }

--- a/src/test/java/edu/ucsb/cs156/example/controllers/ArticlesControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/example/controllers/ArticlesControllerTests.java
@@ -225,7 +225,7 @@ public class ArticlesControllerTests extends ControllerTestCase {
     String requestBody = mapper.writeValueAsString(editedArticle);
 
     when(articlesRepository.findById(eq(67L))).thenReturn(Optional.of(article1));
-    when(articlesRepository.save(article1)).thenReturn(editedArticle);
+    when(articlesRepository.save(article1)).thenAnswer(invocation -> invocation.getArgument(0));
     // act
     MvcResult response =
         mockMvc

--- a/src/test/java/edu/ucsb/cs156/example/controllers/ArticlesControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/example/controllers/ArticlesControllerTests.java
@@ -218,7 +218,7 @@ public class ArticlesControllerTests extends ControllerTestCase {
             .title("To be")
             .url(
                 "https://docs.google.com/presentation/d/1BTg6PEWBjqGG7nBHlcOk1WL7SDR4TywB-SPjUVFyZmY/edit?slide=id.p13#slide=id.p13")
-            .explanation("aa")
+            .explanation("aaa")
             .email("zhao@ucsb.edu")
             .dateAdded(zdt2)
             .build();
@@ -243,7 +243,7 @@ public class ArticlesControllerTests extends ControllerTestCase {
                 jsonPath("$.url")
                     .value(
                         "https://docs.google.com/presentation/d/1BTg6PEWBjqGG7nBHlcOk1WL7SDR4TywB-SPjUVFyZmY/edit?slide=id.p13#slide=id.p13"))
-            .andExpect(jsonPath("$.explanation").value("aa"))
+            .andExpect(jsonPath("$.explanation").value("aaa"))
             .andExpect(jsonPath("$.email").value("zhao@ucsb.edu"))
             .andExpect(jsonPath("$.dateAdded").value("2026-04-14T19:07:18.613Z"))
             .andReturn();
@@ -257,7 +257,7 @@ public class ArticlesControllerTests extends ControllerTestCase {
     assertEquals(
         "https://docs.google.com/presentation/d/1BTg6PEWBjqGG7nBHlcOk1WL7SDR4TywB-SPjUVFyZmY/edit?slide=id.p13#slide=id.p13",
         article1.getUrl());
-    assertEquals("aa", article1.getExplanation());
+    assertEquals("aaa", article1.getExplanation());
     assertEquals("zhao@ucsb.edu", article1.getEmail());
     assertEquals(zdt2, article1.getDateAdded());
 

--- a/src/test/java/edu/ucsb/cs156/example/controllers/ArticlesControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/example/controllers/ArticlesControllerTests.java
@@ -22,6 +22,7 @@ import java.util.Optional;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MvcResult;
@@ -191,5 +192,96 @@ public class ArticlesControllerTests extends ControllerTestCase {
     String expectedJson = mapper.writeValueAsString(article1);
     String responseString = response.getResponse().getContentAsString();
     assertEquals(expectedJson, responseString);
+  }
+
+  @WithMockUser(roles = {"ADMIN", "USER"})
+  @Test
+  public void admin_can_edit_an_existing_article() throws Exception {
+    // arrange
+
+    ZonedDateTime zdt1 = ZonedDateTime.parse("2026-04-24T19:07:18.613Z");
+    ZonedDateTime zdt2 = ZonedDateTime.parse("2026-04-14T19:07:18.613Z");
+
+    Articles article1 =
+        Articles.builder()
+            .title("To be or not To be")
+            .url("https://www.amazon.com/hz/mobile")
+            .explanation("aa")
+            .email("xuanbo@ucsb.edu")
+            .dateAdded(zdt1)
+            .build();
+
+    Articles editedArticle =
+        Articles.builder()
+            .id(67L)
+            .title("To be ")
+            .url(
+                "https://docs.google.com/presentation/d/1BTg6PEWBjqGG7nBHlcOk1WL7SDR4TywB-SPjUVFyZmY/edit?slide=id.p13#slide=id.p13")
+            .explanation("aa")
+            .email("zhao@ucsb.edu")
+            .dateAdded(zdt2)
+            .build();
+
+    String requestBody = mapper.writeValueAsString(editedArticle);
+
+    when(articlesRepository.findById(eq(67L))).thenReturn(Optional.of(article1));
+    when(articlesRepository.save(article1)).thenReturn(editedArticle);
+    // act
+    MvcResult response =
+        mockMvc
+            .perform(
+                put("/api/articles")
+                    .param("id", "67")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .characterEncoding("utf-8")
+                    .content(requestBody)
+                    .with(csrf()))
+            .andExpect(status().isOk())
+            .andReturn();
+
+    // assert
+    verify(articlesRepository, times(1)).findById(67L);
+    verify(articlesRepository, times(1)).save(article1);
+    String responseString = response.getResponse().getContentAsString();
+    assertEquals(requestBody, responseString);
+  }
+
+  @WithMockUser(roles = {"ADMIN", "USER"})
+  @Test
+  public void admin_cannot_edit_ucsbdate_that_does_not_exist() throws Exception {
+    // arrange
+
+    ZonedDateTime zdt1 = ZonedDateTime.parse("2026-04-24T19:07:18.613Z");
+
+    Articles article1 =
+        Articles.builder()
+            .title("To be or not To be")
+            .url("https://www.amazon.com/hz/mobile")
+            .explanation("aa")
+            .email("xuanbo@ucsb.edu")
+            .dateAdded(zdt1)
+            .build();
+
+    String requestBody = mapper.writeValueAsString(article1);
+
+    when(articlesRepository.findById(eq(67L))).thenReturn(Optional.empty());
+
+    // act
+    MvcResult response =
+        mockMvc
+            .perform(
+                put("/api/articles")
+                    .param("id", "67")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .characterEncoding("utf-8")
+                    .content(requestBody)
+                    .with(csrf()))
+            .andExpect(status().isNotFound())
+            .andReturn();
+
+    // assert
+    verify(articlesRepository, times(1)).findById(67L);
+    Map<String, Object> json = responseToJson(response);
+    assertEquals("Articles with id 67 not found", json.get("message"));
   }
 }

--- a/src/test/java/edu/ucsb/cs156/example/controllers/ArticlesControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/example/controllers/ArticlesControllerTests.java
@@ -204,6 +204,7 @@ public class ArticlesControllerTests extends ControllerTestCase {
 
     Articles article1 =
         Articles.builder()
+            .id(67L)
             .title("To be or not To be")
             .url("https://www.amazon.com/hz/mobile")
             .explanation("aa")
@@ -250,6 +251,16 @@ public class ArticlesControllerTests extends ControllerTestCase {
     // assert
     verify(articlesRepository, times(1)).findById(67L);
     verify(articlesRepository, times(1)).save(article1);
+
+    // ✅ Add these to kill the surviving mutations
+    assertEquals("To be", article1.getTitle());
+    assertEquals(
+        "https://docs.google.com/presentation/d/1BTg6PEWBjqGG7nBHlcOk1WL7SDR4TywB-SPjUVFyZmY/edit?slide=id.p13#slide=id.p13",
+        article1.getUrl());
+    assertEquals("aa", article1.getExplanation());
+    assertEquals("zhao@ucsb.edu", article1.getEmail());
+    assertEquals(zdt2, article1.getDateAdded());
+
     String responseString = response.getResponse().getContentAsString();
     assertEquals(requestBody, responseString);
   }

--- a/src/test/java/edu/ucsb/cs156/example/controllers/ArticlesControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/example/controllers/ArticlesControllerTests.java
@@ -214,7 +214,7 @@ public class ArticlesControllerTests extends ControllerTestCase {
     Articles editedArticle =
         Articles.builder()
             .id(67L)
-            .title("To be ")
+            .title("To be")
             .url(
                 "https://docs.google.com/presentation/d/1BTg6PEWBjqGG7nBHlcOk1WL7SDR4TywB-SPjUVFyZmY/edit?slide=id.p13#slide=id.p13")
             .explanation("aa")
@@ -237,6 +237,14 @@ public class ArticlesControllerTests extends ControllerTestCase {
                     .content(requestBody)
                     .with(csrf()))
             .andExpect(status().isOk())
+            .andExpect(jsonPath("$.title").value("To be"))
+            .andExpect(
+                jsonPath("$.url")
+                    .value(
+                        "https://docs.google.com/presentation/d/1BTg6PEWBjqGG7nBHlcOk1WL7SDR4TywB-SPjUVFyZmY/edit?slide=id.p13#slide=id.p13"))
+            .andExpect(jsonPath("$.explanation").value("aa"))
+            .andExpect(jsonPath("$.email").value("zhao@ucsb.edu"))
+            .andExpect(jsonPath("$.dateAdded").value("2026-04-14T19:07:18.613Z"))
             .andReturn();
 
     // assert

--- a/src/test/java/edu/ucsb/cs156/example/controllers/ArticlesControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/example/controllers/ArticlesControllerTests.java
@@ -303,4 +303,58 @@ public class ArticlesControllerTests extends ControllerTestCase {
     Map<String, Object> json = responseToJson(response);
     assertEquals("Articles with id 67 not found", json.get("message"));
   }
+
+  @WithMockUser(roles = {"ADMIN", "USER"})
+  @Test
+  public void admin_can_delete_an_article() throws Exception {
+    // arrange
+
+    ZonedDateTime zdt1 = ZonedDateTime.parse("2026-04-24T19:07:18.613Z");
+
+    Articles article1 =
+        Articles.builder()
+            .title("To be or not To be")
+            .url("https://www.amazon.com/hz/mobile")
+            .explanation("aa")
+            .email("xuanbo@ucsb.edu")
+            .dateAdded(zdt1)
+            .build();
+
+    when(articlesRepository.findById(eq(67L))).thenReturn(Optional.of(article1));
+
+    // act
+    MvcResult response =
+        mockMvc
+            .perform(delete("/api/articles").param("id", "67").with(csrf()))
+            .andExpect(status().isOk())
+            .andReturn();
+
+    // assert
+    verify(articlesRepository, times(1)).findById(67L);
+    verify(articlesRepository, times(1)).delete(eq(article1));
+
+    Map<String, Object> json = responseToJson(response);
+    assertEquals("Article with id 67 deleted", json.get("message"));
+  }
+
+  @WithMockUser(roles = {"ADMIN", "USER"})
+  @Test
+  public void admin_tries_to_delete_non_existant_article_and_gets_right_error_message()
+      throws Exception {
+    // arrange
+
+    when(articlesRepository.findById(eq(15L))).thenReturn(Optional.empty());
+
+    // act
+    MvcResult response =
+        mockMvc
+            .perform(delete("/api/articles").param("id", "15").with(csrf()))
+            .andExpect(status().isNotFound())
+            .andReturn();
+
+    // assert
+    verify(articlesRepository, times(1)).findById(15L);
+    Map<String, Object> json = responseToJson(response);
+    assertEquals("Articles with id 15 not found", json.get("message"));
+  }
 }


### PR DESCRIPTION
Closes #42
In this PR, we add the delete endpoint for the Article table, 

<img width="1411" height="907" alt="Screenshot 2026-04-27 at 12 19 59" src="https://github.com/user-attachments/assets/b0b5d64a-6acd-4bcf-b6fa-a0aab0184ec4" />
<img width="1384" height="771" alt="Screenshot 2026-04-27 at 12 20 21" src="https://github.com/user-attachments/assets/543c0793-1501-4b60-9e01-d9afbafe98cc" />
<img width="1406" height="763" alt="Screenshot 2026-04-27 at 12 20 37" src="https://github.com/user-attachments/assets/3ecee186-c5b9-42e2-9564-0262fd3494a0" />
