### PR TITLE
Joy -  add GET by id for UCSBOrganization

### DIFF
--- a/src/main/java/edu/ucsb/cs156/example/controllers/UCSBOrganizationsController.java
+++ b/src/main/java/edu/ucsb/cs156/example/controllers/UCSBOrganizationsController.java
@@ -1,0 +1,67 @@
+package edu.ucsb.cs156.example.controllers;
+
+import edu.ucsb.cs156.example.entities.UCSBOrganization;
+import edu.ucsb.cs156.example.repositories.UCSBOrganizationRepository;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+/** This is a REST controller for UCSBOrganizations */
+@Tag(name = "UCSBOrganizations")
+@RequestMapping("/api/ucsborganizations")
+@RestController
+@Slf4j
+public class UCSBOrganizationsController extends ApiController {
+
+  @Autowired UCSBOrganizationRepository ucsbOrganizationRepository;
+
+  /**
+   * List all UCSB organizations
+   *
+   * @return an iterable of UCSBOrganization
+   */
+  @Operation(summary = "List all ucsb organizations")
+  @PreAuthorize("hasRole('ROLE_USER')")
+  @GetMapping("/all")
+  public Iterable<UCSBOrganization> allUCSBOrganizations() {
+    Iterable<UCSBOrganization> organizations = ucsbOrganizationRepository.findAll();
+    return organizations;
+  }
+
+  /**
+   * Create a new date
+   *
+   * @param orgCode the organization code
+   * @param orgTranslationShort the translation of code shortened
+   * @param orgTranslation the translation of code
+   * @param inactive whether the organization is inactive
+   * @return the saved ucsborganization
+   */
+  @Operation(summary = "Create a new organization")
+  @PreAuthorize("hasRole('ROLE_ADMIN')")
+  @PostMapping("/post")
+  public UCSBOrganization postUCSBOrganization(
+      @Parameter(name = "orgCode") @RequestParam String orgCode,
+      @Parameter(name = "orgTranslationShort") @RequestParam String orgTranslationShort,
+      @Parameter(name = "orgTranslation") @RequestParam String orgTranslation,
+      @Parameter(name = "inactive") @RequestParam Boolean inactive) {
+
+    UCSBOrganization ucsbOrganization = new UCSBOrganization();
+    ucsbOrganization.setOrgCode(orgCode);
+    ucsbOrganization.setOrgTranslationShort(orgTranslationShort);
+    ucsbOrganization.setOrgTranslation(orgTranslation);
+    ucsbOrganization.setInactive(inactive);
+
+    UCSBOrganization savedUcsbOrganization = ucsbOrganizationRepository.save(ucsbOrganization);
+
+    return savedUcsbOrganization;
+  }
+}

--- a/src/main/java/edu/ucsb/cs156/example/controllers/UCSBOrganizationsController.java
+++ b/src/main/java/edu/ucsb/cs156/example/controllers/UCSBOrganizationsController.java
@@ -1,6 +1,7 @@
 package edu.ucsb.cs156.example.controllers;
 
 import edu.ucsb.cs156.example.entities.UCSBOrganization;
+import edu.ucsb.cs156.example.errors.EntityNotFoundException;
 import edu.ucsb.cs156.example.repositories.UCSBOrganizationRepository;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -63,5 +64,23 @@ public class UCSBOrganizationsController extends ApiController {
     UCSBOrganization savedUcsbOrganization = ucsbOrganizationRepository.save(ucsbOrganization);
 
     return savedUcsbOrganization;
+  }
+
+  /**
+   * This method returns a single organization.
+   *
+   * @param orgCode code of the organization
+   * @return a single organization
+   */
+  @Operation(summary = "Get a single organization")
+  @PreAuthorize("hasRole('ROLE_USER')")
+  @GetMapping("")
+  public UCSBOrganization getById(@Parameter(name = "orgCode") @RequestParam String orgCode) {
+    UCSBOrganization organizations =
+        ucsbOrganizationRepository
+            .findById(orgCode)
+            .orElseThrow(() -> new EntityNotFoundException(UCSBOrganization.class, orgCode));
+
+    return organizations;
   }
 }

--- a/src/main/java/edu/ucsb/cs156/example/repositories/UCSBOrganizationRepository.java
+++ b/src/main/java/edu/ucsb/cs156/example/repositories/UCSBOrganizationRepository.java
@@ -8,4 +8,4 @@ import org.springframework.stereotype.Repository;
 /** The UCSBOrganizationsRepository is a repository for UCSBOrganization entities. */
 @Repository
 @RepositoryRestResource(exported = false)
-public interface UCSBOrganizationRepository extends CrudRepository<UCSBOrganization, Long> {}
+public interface UCSBOrganizationRepository extends CrudRepository<UCSBOrganization, String> {}

--- a/src/test/java/edu/ucsb/cs156/example/controllers/UCSBDiningCommonsControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/example/controllers/UCSBDiningCommonsControllerTests.java
@@ -197,6 +197,8 @@ public class UCSBDiningCommonsControllerTests extends ControllerTestCase {
     assertEquals(expectedJson, responseString);
   }
 
+  //////
+
   @WithMockUser(roles = {"ADMIN", "USER"})
   @Test
   public void an_admin_user_can_post_a_new_commons() throws Exception {

--- a/src/test/java/edu/ucsb/cs156/example/controllers/UCSBOrganizationsControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/example/controllers/UCSBOrganizationsControllerTests.java
@@ -65,7 +65,7 @@ public class UCSBOrganizationsControllerTests extends ControllerTestCase {
             .orgCode("AACF")
             .orgTranslationShort("Asian American Christian Fellowship")
             .orgTranslation("UCSB Asian American Christian Fellowship")
-            .inactive(false)
+            .inactive(true)
             .build();
 
     ArrayList<UCSBOrganization> expectedOrganizations = new ArrayList<>();

--- a/src/test/java/edu/ucsb/cs156/example/controllers/UCSBOrganizationsControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/example/controllers/UCSBOrganizationsControllerTests.java
@@ -1,0 +1,117 @@
+package edu.ucsb.cs156.example.controllers;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import edu.ucsb.cs156.example.ControllerTestCase;
+import edu.ucsb.cs156.example.entities.UCSBOrganization;
+import edu.ucsb.cs156.example.repositories.UCSBOrganizationRepository;
+import edu.ucsb.cs156.example.repositories.UserRepository;
+import edu.ucsb.cs156.example.testconfig.TestConfig;
+import java.util.ArrayList;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MvcResult;
+
+@WebMvcTest(controllers = UCSBOrganizationsController.class)
+@Import(TestConfig.class)
+public class UCSBOrganizationsControllerTests extends ControllerTestCase {
+
+  @MockitoBean UCSBOrganizationRepository ucsbOrganizationRepository;
+
+  @MockitoBean UserRepository userRepository;
+
+  @Test
+  public void logged_out_users_cannot_get_all() throws Exception {
+    mockMvc
+        .perform(get("/api/ucsborganizations/all"))
+        .andExpect(status().is(403)); // logged out users can't get all
+  }
+
+  @WithMockUser(roles = {"USER"})
+  @Test
+  public void logged_in_users_can_get_all() throws Exception {
+    mockMvc.perform(get("/api/ucsborganizations/all")).andExpect(status().is(200)); // logged
+  }
+
+  @Test
+  public void logged_out_users_cannot_post() throws Exception {
+    mockMvc.perform(post("/api/ucsborganizations/post")).andExpect(status().is(403));
+  }
+
+  @WithMockUser(roles = {"USER"})
+  @Test
+  public void logged_in_regular_users_cannot_post() throws Exception {
+    mockMvc
+        .perform(post("/api/ucsborganizations/post"))
+        .andExpect(status().is(403)); // only admins can post
+  }
+
+  @WithMockUser(roles = {"USER"})
+  @Test
+  public void logged_in_user_can_get_all_ucsborganizations() throws Exception {
+
+    UCSBOrganization ucsbOrganization1 =
+        UCSBOrganization.builder()
+            .orgCode("AACF")
+            .orgTranslationShort("Asian American Christian Fellowship")
+            .orgTranslation("UCSB Asian American Christian Fellowship")
+            .inactive(false)
+            .build();
+
+    ArrayList<UCSBOrganization> expectedOrganizations = new ArrayList<>();
+    expectedOrganizations.add(ucsbOrganization1);
+
+    when(ucsbOrganizationRepository.findAll()).thenReturn(expectedOrganizations);
+
+    // act
+    MvcResult response =
+        mockMvc.perform(get("/api/ucsborganizations/all")).andExpect(status().isOk()).andReturn();
+
+    // assert
+
+    verify(ucsbOrganizationRepository, times(1)).findAll();
+    String expectedJson = mapper.writeValueAsString(expectedOrganizations);
+    String responseString = response.getResponse().getContentAsString();
+    assertEquals(expectedJson, responseString);
+  }
+
+  @WithMockUser(roles = {"ADMIN", "USER"})
+  @Test
+  public void an_admin_user_can_post_a_new_ucsborganization() throws Exception {
+
+    UCSBOrganization ucsbOrganization1 =
+        UCSBOrganization.builder()
+            .orgCode("AACF")
+            .orgTranslationShort("AsianAmericanChristianFellowship")
+            .orgTranslation("UCSBAsianAmericanChristianFellowship")
+            .inactive(false)
+            .build();
+
+    when(ucsbOrganizationRepository.save(eq(ucsbOrganization1))).thenReturn(ucsbOrganization1);
+
+    // act
+    MvcResult response =
+        mockMvc
+            .perform(
+                post("/api/ucsborganizations/post?orgCode=AACF&orgTranslationShort=AsianAmericanChristianFellowship&orgTranslation=UCSBAsianAmericanChristianFellowship&inactive=false")
+                    .with(csrf()))
+            .andExpect(status().isOk())
+            .andReturn();
+
+    // assert
+    verify(ucsbOrganizationRepository, times(1)).save(ucsbOrganization1);
+    String expectedJson = mapper.writeValueAsString(ucsbOrganization1);
+    String responseString = response.getResponse().getContentAsString();
+    assertEquals(expectedJson, responseString);
+  }
+}

--- a/src/test/java/edu/ucsb/cs156/example/controllers/UCSBOrganizationsControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/example/controllers/UCSBOrganizationsControllerTests.java
@@ -15,6 +15,8 @@ import edu.ucsb.cs156.example.repositories.UCSBOrganizationRepository;
 import edu.ucsb.cs156.example.repositories.UserRepository;
 import edu.ucsb.cs156.example.testconfig.TestConfig;
 import java.util.ArrayList;
+import java.util.Map;
+import java.util.Optional;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.context.annotation.Import;
@@ -113,5 +115,68 @@ public class UCSBOrganizationsControllerTests extends ControllerTestCase {
     String expectedJson = mapper.writeValueAsString(ucsbOrganization1);
     String responseString = response.getResponse().getContentAsString();
     assertEquals(expectedJson, responseString);
+  }
+
+  @Test
+  public void logged_out_users_cannot_get_by_id() throws Exception {
+    mockMvc
+        .perform(get("/api/ucsborganizations").param("orgCode", "a2f"))
+        .andExpect(status().is(403)); // logged out users can't get by id
+  }
+
+  // Tests with mocks for database actions
+
+  @WithMockUser(roles = {"USER"})
+  @Test
+  public void test_that_logged_in_user_can_get_by_id_when_the_id_exists() throws Exception {
+
+    // arrange
+
+    UCSBOrganization organizations =
+        UCSBOrganization.builder()
+            .orgCode("A2F")
+            .orgTranslationShort("Acts2Fellowship")
+            .orgTranslation("UCSBActs2Fellowship")
+            .inactive(true)
+            .build();
+
+    when(ucsbOrganizationRepository.findById(eq("A2F"))).thenReturn(Optional.of(organizations));
+
+    // act
+    MvcResult response =
+        mockMvc
+            .perform(get("/api/ucsborganizations").param("orgCode", "A2F"))
+            .andExpect(status().isOk())
+            .andReturn();
+
+    // assert
+
+    verify(ucsbOrganizationRepository, times(1)).findById(eq("A2F"));
+    String expectedJson = mapper.writeValueAsString(organizations);
+    String responseString = response.getResponse().getContentAsString();
+    assertEquals(expectedJson, responseString);
+  }
+
+  @WithMockUser(roles = {"USER"})
+  @Test
+  public void test_that_logged_in_user_can_get_by_id_when_the_id_does_not_exist() throws Exception {
+
+    // arrange
+
+    when(ucsbOrganizationRepository.findById(eq("munger-hall"))).thenReturn(Optional.empty());
+
+    // act
+    MvcResult response =
+        mockMvc
+            .perform(get("/api/ucsborganizations").param("orgCode", "munger-hall"))
+            .andExpect(status().isNotFound())
+            .andReturn();
+
+    // assert
+
+    verify(ucsbOrganizationRepository, times(1)).findById(eq("munger-hall"));
+    Map<String, Object> json = responseToJson(response);
+    assertEquals("EntityNotFoundException", json.get("type"));
+    assertEquals("UCSBOrganization with id munger-hall not found", json.get("message"));
   }
 }

--- a/src/test/java/edu/ucsb/cs156/example/controllers/UCSBOrganizationsControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/example/controllers/UCSBOrganizationsControllerTests.java
@@ -94,7 +94,7 @@ public class UCSBOrganizationsControllerTests extends ControllerTestCase {
             .orgCode("AACF")
             .orgTranslationShort("AsianAmericanChristianFellowship")
             .orgTranslation("UCSBAsianAmericanChristianFellowship")
-            .inactive(false)
+            .inactive(true)
             .build();
 
     when(ucsbOrganizationRepository.save(eq(ucsbOrganization1))).thenReturn(ucsbOrganization1);
@@ -103,7 +103,7 @@ public class UCSBOrganizationsControllerTests extends ControllerTestCase {
     MvcResult response =
         mockMvc
             .perform(
-                post("/api/ucsborganizations/post?orgCode=AACF&orgTranslationShort=AsianAmericanChristianFellowship&orgTranslation=UCSBAsianAmericanChristianFellowship&inactive=false")
+                post("/api/ucsborganizations/post?orgCode=AACF&orgTranslationShort=AsianAmericanChristianFellowship&orgTranslation=UCSBAsianAmericanChristianFellowship&inactive=true")
                     .with(csrf()))
             .andExpect(status().isOk())
             .andReturn();


### PR DESCRIPTION
Closes #16 

In this PR, we add another endpoint to the UCSBOrganization controller, one that allows us to GET an organization by its' orgCode. 

<img width="774" height="630" alt="Screenshot 2026-04-28 at 5 41 02 PM" src="https://github.com/user-attachments/assets/4eb28615-2683-4eab-bb2d-101ead565f47" />
