### PR TITLE
jc - add test coverage to PUT

### DIFF
--- a/src/main/java/edu/ucsb/cs156/example/controllers/UCSBOrganizationsController.java
+++ b/src/main/java/edu/ucsb/cs156/example/controllers/UCSBOrganizationsController.java
@@ -6,11 +6,14 @@ import edu.ucsb.cs156.example.repositories.UCSBOrganizationRepository;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -80,6 +83,34 @@ public class UCSBOrganizationsController extends ApiController {
         ucsbOrganizationRepository
             .findById(orgCode)
             .orElseThrow(() -> new EntityNotFoundException(UCSBOrganization.class, orgCode));
+
+    return organizations;
+  }
+
+  /**
+   * Update a single organization. Accessible only to users with the role "ROLE_ADMIN".
+   *
+   * @param orgCode code of the organization
+   * @param incoming the new organizations contents
+   * @return the updated commons object
+   */
+  @Operation(summary = "Update a single organization")
+  @PreAuthorize("hasRole('ROLE_ADMIN')")
+  @PutMapping("")
+  public UCSBOrganization updateOrganization(
+      @Parameter(name = "orgCode") @RequestParam String orgCode,
+      @RequestBody @Valid UCSBOrganization incoming) {
+
+    UCSBOrganization organizations =
+        ucsbOrganizationRepository
+            .findById(orgCode)
+            .orElseThrow(() -> new EntityNotFoundException(UCSBOrganization.class, orgCode));
+
+    organizations.setOrgTranslation(incoming.getOrgTranslation());
+    organizations.setOrgTranslationShort(incoming.getOrgTranslationShort());
+    organizations.setInactive(incoming.getInactive());
+
+    ucsbOrganizationRepository.save(organizations);
 
     return organizations;
   }

--- a/src/test/java/edu/ucsb/cs156/example/controllers/UCSBOrganizationsControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/example/controllers/UCSBOrganizationsControllerTests.java
@@ -190,7 +190,7 @@ public class UCSBOrganizationsControllerTests extends ControllerTestCase {
         UCSBOrganization.builder()
             .orgCode("Epic")
             .orgTranslation("EpicMovementCru")
-            .orgTranslation("EpicMovement")
+            .orgTranslationShort("EpicMovement")
             .inactive(true)
             .build();
 
@@ -198,7 +198,7 @@ public class UCSBOrganizationsControllerTests extends ControllerTestCase {
         UCSBOrganization.builder()
             .orgCode("Epic")
             .orgTranslation("UCSBEpicMovementCru")
-            .orgTranslation("UCSBEpicMovement")
+            .orgTranslationShort("UCSBEpicMovement")
             .inactive(false)
             .build();
 

--- a/src/test/java/edu/ucsb/cs156/example/controllers/UCSBOrganizationsControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/example/controllers/UCSBOrganizationsControllerTests.java
@@ -20,6 +20,7 @@ import java.util.Optional;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MvcResult;
@@ -178,5 +179,87 @@ public class UCSBOrganizationsControllerTests extends ControllerTestCase {
     Map<String, Object> json = responseToJson(response);
     assertEquals("EntityNotFoundException", json.get("type"));
     assertEquals("UCSBOrganization with id munger-hall not found", json.get("message"));
+  }
+
+  @WithMockUser(roles = {"ADMIN", "USER"})
+  @Test
+  public void admin_can_edit_an_existing_organization() throws Exception {
+    // arrange
+
+    UCSBOrganization epicOrig =
+        UCSBOrganization.builder()
+            .orgCode("Epic")
+            .orgTranslation("EpicMovementCru")
+            .orgTranslation("EpicMovement")
+            .inactive(true)
+            .build();
+
+    UCSBOrganization epicEdited =
+        UCSBOrganization.builder()
+            .orgCode("Epic")
+            .orgTranslation("UCSBEpicMovementCru")
+            .orgTranslation("UCSBEpicMovement")
+            .inactive(false)
+            .build();
+
+    String requestBody = mapper.writeValueAsString(epicEdited);
+
+    when(ucsbOrganizationRepository.findById(eq("Epic"))).thenReturn(Optional.of(epicOrig));
+
+    // act
+    MvcResult response =
+        mockMvc
+            .perform(
+                put("/api/ucsborganizations")
+                    .param("orgCode", "Epic")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .characterEncoding("utf-8")
+                    .content(requestBody)
+                    .with(csrf()))
+            .andExpect(status().isOk())
+            .andReturn();
+
+    // assert
+    verify(ucsbOrganizationRepository, times(1)).findById("Epic");
+    verify(ucsbOrganizationRepository, times(1))
+        .save(epicEdited); // should be saved with updated info
+    String responseString = response.getResponse().getContentAsString();
+    assertEquals(requestBody, responseString);
+  }
+
+  @WithMockUser(roles = {"ADMIN", "USER"})
+  @Test
+  public void admin_cannot_edit_organization_that_does_not_exist() throws Exception {
+    // arrange
+
+    UCSBOrganization editedOrganization =
+        UCSBOrganization.builder()
+            .orgCode("MG")
+            .orgTranslation("munger-hall-ucsb")
+            .orgTranslationShort("munger-hall")
+            .inactive(true)
+            .build();
+
+    String requestBody = mapper.writeValueAsString(editedOrganization);
+
+    when(ucsbOrganizationRepository.findById(eq("MG"))).thenReturn(Optional.empty());
+
+    // act
+    MvcResult response =
+        mockMvc
+            .perform(
+                put("/api/ucsborganizations")
+                    .param("orgCode", "MG")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .characterEncoding("utf-8")
+                    .content(requestBody)
+                    .with(csrf()))
+            .andExpect(status().isNotFound())
+            .andReturn();
+
+    // assert
+    verify(ucsbOrganizationRepository, times(1)).findById("MG");
+    Map<String, Object> json = responseToJson(response);
+    assertEquals("UCSBOrganization with id MG not found", json.get("message"));
   }
 }


### PR DESCRIPTION
Closes #17 

In this PR, we add a PUT operation in the UCSBOrganizationController so that we will be able to edit existing commits. 

<img width="702" height="508" alt="Screenshot 2026-04-29 at 1 20 37 AM" src="https://github.com/user-attachments/assets/0c82433d-3dfe-47cf-9c87-25fd96091e61" />
