### PR TITLE
Add RecommendationRequest controller with GET /all and POST /post

### DIFF
--- a/src/main/java/edu/ucsb/cs156/example/controllers/RecommendationRequestController.java
+++ b/src/main/java/edu/ucsb/cs156/example/controllers/RecommendationRequestController.java
@@ -1,0 +1,91 @@
+package edu.ucsb.cs156.example.controllers;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import edu.ucsb.cs156.example.entities.RecommendationRequest;
+import edu.ucsb.cs156.example.repositories.RecommendationRequestRepository;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import java.time.LocalDateTime;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+/** This is a REST controller for RecommendationRequest */
+@Tag(name = "RecommendationRequest")
+@RestController
+@RequestMapping("/api/RecommendationRequest")
+@Slf4j
+public class RecommendationRequestController extends ApiController {
+
+  @Autowired RecommendationRequestRepository recommendationRequestRepository;
+
+  /**
+   * List all RecommendationRequests
+   *
+   * @return an iterable of RecommendationRequest
+   */
+  @Operation(summary = "List all recommendation requests")
+  @PreAuthorize("hasRole('ROLE_USER')")
+  @GetMapping("/all")
+  public Iterable<RecommendationRequest> allRecommendationRequests() {
+    Iterable<RecommendationRequest> requests = recommendationRequestRepository.findAll();
+    return requests;
+  }
+
+  /**
+   * Create a new RecommendationRequest
+   *
+   * @param requesterEmail email of the requester
+   * @param professorEmail email of the professor
+   * @param explanation explanation of the request
+   * @param dateRequested date the request was made
+   * @param dateNeeded date the recommendation is needed
+   * @param done whether the request is done
+   * @return the saved RecommendationRequest
+   */
+  @Operation(summary = "Create a new recommendation request")
+  @PreAuthorize("hasRole('ROLE_ADMIN')")
+  @PostMapping("/post")
+  public RecommendationRequest postRecommendationRequest(
+      @Parameter(name = "requesterEmail") @RequestParam String requesterEmail,
+      @Parameter(name = "professorEmail") @RequestParam String professorEmail,
+      @Parameter(name = "explanation") @RequestParam String explanation,
+      @Parameter(
+              name = "dateRequested",
+              description =
+                  "date (in iso format, e.g. YYYY-mm-ddTHH:MM:SS; see https://en.wikipedia.org/wiki/ISO_8601)")
+          @RequestParam("dateRequested")
+          @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
+          LocalDateTime dateRequested,
+      @Parameter(
+              name = "dateNeeded",
+              description =
+                  "date (in iso format, e.g. YYYY-mm-ddTHH:MM:SS; see https://en.wikipedia.org/wiki/ISO_8601)")
+          @RequestParam("dateNeeded")
+          @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
+          LocalDateTime dateNeeded,
+      @Parameter(name = "done") @RequestParam boolean done)
+      throws JsonProcessingException {
+
+    log.info("dateRequested={} dateNeeded={}", dateRequested, dateNeeded);
+
+    RecommendationRequest recommendationRequest = new RecommendationRequest();
+    recommendationRequest.setRequesterEmail(requesterEmail);
+    recommendationRequest.setProfessorEmail(professorEmail);
+    recommendationRequest.setExplanation(explanation);
+    recommendationRequest.setDateRequested(dateRequested);
+    recommendationRequest.setDateNeeded(dateNeeded);
+    recommendationRequest.setDone(done);
+
+    RecommendationRequest savedRequest =
+        recommendationRequestRepository.save(recommendationRequest);
+    return savedRequest;
+  }
+}

--- a/src/main/java/edu/ucsb/cs156/example/entities/RecommendationRequest.java
+++ b/src/main/java/edu/ucsb/cs156/example/entities/RecommendationRequest.java
@@ -1,0 +1,33 @@
+package edu.ucsb.cs156.example.entities;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import java.time.LocalDateTime;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * This is a JPA entity that represents a UCSBRecommendationRequest, i.e. an entry that comes from
+ * the UCSB API for academic calendar dates.
+ */
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+@Entity(name = "recommendationrequests")
+public class RecommendationRequest {
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private long id;
+
+  private String requesterEmail;
+  private String professorEmail;
+  private String explanation;
+  private LocalDateTime dateRequested;
+  private LocalDateTime dateNeeded;
+  private boolean done;
+}

--- a/src/main/java/edu/ucsb/cs156/example/entities/RecommendationRequest.java
+++ b/src/main/java/edu/ucsb/cs156/example/entities/RecommendationRequest.java
@@ -18,7 +18,7 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 @NoArgsConstructor
 @Builder
-@Entity(name = "recommendationrequests")
+@Entity(name = "recommendation_requests")
 public class RecommendationRequest {
   @Id
   @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/edu/ucsb/cs156/example/repositories/RecommendationRequestRepository.java
+++ b/src/main/java/edu/ucsb/cs156/example/repositories/RecommendationRequestRepository.java
@@ -1,0 +1,12 @@
+package edu.ucsb.cs156.example.repositories;
+
+import edu.ucsb.cs156.example.entities.RecommendationRequest;
+import org.springframework.data.repository.CrudRepository;
+import org.springframework.data.rest.core.annotation.RepositoryRestResource;
+import org.springframework.stereotype.Repository;
+
+/** The UCSBDateRepository is a repository for RecommendationRequest entities. */
+@Repository
+@RepositoryRestResource(exported = false)
+public interface RecommendationRequestRepository
+    extends CrudRepository<RecommendationRequest, Long> {}

--- a/src/main/resources/db/migration/changes/RecommendationRequest.json
+++ b/src/main/resources/db/migration/changes/RecommendationRequest.json
@@ -1,0 +1,80 @@
+{
+    "databaseChangeLog": [
+      {
+        "changeSet": {
+          "id": "RecommendationRequests-1",
+          "author": "你的GitHub用户名",
+          "preConditions": [
+            {
+              "onFail": "MARK_RAN"
+            },
+            {
+              "not": [
+                {
+                  "tableExists": {
+                    "tableName": "RECOMMENDATION_REQUESTS"
+                  }
+                }
+              ]
+            }
+          ],
+          "changes": [
+            {
+              "createTable": {
+                "columns": [
+                  {
+                    "column": {
+                      "autoIncrement": true,
+                      "constraints": {
+                        "primaryKey": true,
+                        "primaryKeyName": "RECOMMENDATION_REQUESTS_PK"
+                      },
+                      "name": "ID",
+                      "type": "BIGINT"
+                    }
+                  },
+                  {
+                    "column": {
+                      "name": "REQUESTER_EMAIL",
+                      "type": "VARCHAR(255)"
+                    }
+                  },
+                  {
+                    "column": {
+                      "name": "PROFESSOR_EMAIL",
+                      "type": "VARCHAR(255)"
+                    }
+                  },
+                  {
+                    "column": {
+                      "name": "EXPLANATION",
+                      "type": "VARCHAR(255)"
+                    }
+                  },
+                  {
+                    "column": {
+                      "name": "DATE_REQUESTED",
+                      "type": "TIMESTAMP WITHOUT TIME ZONE"
+                    }
+                  },
+                  {
+                    "column": {
+                      "name": "DATE_NEEDED",
+                      "type": "TIMESTAMP WITHOUT TIME ZONE"
+                    }
+                  },
+                  {
+                    "column": {
+                      "name": "DONE",
+                      "type": "BOOLEAN"
+                    }
+                  }
+                ],
+                "tableName": "RECOMMENDATION_REQUESTS"
+              }
+            }
+          ]
+        }
+      }
+    ]
+  }

--- a/src/test/java/edu/ucsb/cs156/example/controllers/RecommendationRequestControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/example/controllers/RecommendationRequestControllerTests.java
@@ -1,0 +1,179 @@
+package edu.ucsb.cs156.example.controllers;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import edu.ucsb.cs156.example.ControllerTestCase;
+import edu.ucsb.cs156.example.entities.RecommendationRequest;
+import edu.ucsb.cs156.example.repositories.RecommendationRequestRepository;
+import edu.ucsb.cs156.example.repositories.UserRepository;
+import edu.ucsb.cs156.example.testconfig.TestConfig;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.Arrays;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MvcResult;
+
+@WebMvcTest(controllers = RecommendationRequestController.class)
+@Import(TestConfig.class)
+public class RecommendationRequestControllerTests extends ControllerTestCase {
+
+  @MockitoBean RecommendationRequestRepository recommendationRequestRepository;
+
+  @MockitoBean UserRepository userRepository;
+
+  // Authorization tests for /api/RecommendationRequest/admin/all
+
+  @Test
+  public void logged_out_users_cannot_get_all() throws Exception {
+    mockMvc
+        .perform(get("/api/RecommendationRequest/all"))
+        .andExpect(status().is(403)); // logged out users can't get all
+  }
+
+  @WithMockUser(roles = {"USER"})
+  @Test
+  public void logged_in_users_can_get_all() throws Exception {
+    mockMvc.perform(get("/api/RecommendationRequest/all")).andExpect(status().is(200)); // logged
+  }
+
+  // Authorization tests for /api/RecommendationRequest/post
+  // (Perhaps should also have these for put and delete)
+
+  @Test
+  public void logged_out_users_cannot_post() throws Exception {
+    mockMvc
+        .perform(
+            post("/api/RecommendationRequest/post")
+                .param("requesterEmail", "cgaucho@ucsb.edu")
+                .param("professorEmail", "phtcon@ucsb.edu")
+                .param("explanation", "BS/MS program")
+                .param("dateRequested", "2022-04-20T00:00:00")
+                .param("dateNeeded", "2022-05-01T00:00:00")
+                .param("done", "false")
+                .with(csrf()))
+        .andExpect(status().is(403));
+  }
+
+  @WithMockUser(roles = {"USER"})
+  @Test
+  public void logged_in_regular_users_cannot_post() throws Exception {
+    mockMvc
+        .perform(
+            post("/api/RecommendationRequest/post")
+                .param("requesterEmail", "cgaucho@ucsb.edu")
+                .param("professorEmail", "phtcon@ucsb.edu")
+                .param("explanation", "BS/MS program")
+                .param("dateRequested", "2022-04-20T00:00:00")
+                .param("dateNeeded", "2022-05-01T00:00:00")
+                .param("done", "false")
+                .with(csrf()))
+        .andExpect(status().is(403)); // only admins can post
+  }
+
+  // // Tests with mocks for database actions
+
+  @WithMockUser(roles = {"USER"})
+  @Test
+  public void logged_in_user_can_get_all_recommendationrequests() throws Exception {
+
+    // arrange
+    LocalDateTime ldt1 = LocalDateTime.parse("2022-04-20T00:00:00");
+    LocalDateTime ldt2 = LocalDateTime.parse("2022-05-01T00:00:00");
+
+    RecommendationRequest recommendationRequest1 =
+        RecommendationRequest.builder()
+            .requesterEmail("cgaucho@ucsb.edu")
+            .professorEmail("phtcon@ucsb.edu")
+            .explanation("BS/MS program")
+            .dateRequested(ldt1)
+            .dateNeeded(ldt2)
+            .done(false)
+            .build();
+
+    LocalDateTime ldt3 = LocalDateTime.parse("2022-05-20T00:00:00");
+    LocalDateTime ldt4 = LocalDateTime.parse("2022-11-15T00:00:00");
+
+    RecommendationRequest recommendationRequest2 =
+        RecommendationRequest.builder()
+            .requesterEmail("ldelplaya@ucsb.edu")
+            .professorEmail("richert@ucsb.edu")
+            .explanation("PhD CS Stanford")
+            .dateRequested(ldt3)
+            .dateNeeded(ldt4)
+            .done(false)
+            .build();
+
+    ArrayList<RecommendationRequest> expectedRequests = new ArrayList<>();
+    expectedRequests.addAll(Arrays.asList(recommendationRequest1, recommendationRequest2));
+
+    when(recommendationRequestRepository.findAll()).thenReturn(expectedRequests);
+
+    // act
+    MvcResult response =
+        mockMvc
+            .perform(get("/api/RecommendationRequest/all"))
+            .andExpect(status().isOk())
+            .andReturn();
+
+    // assert
+
+    verify(recommendationRequestRepository, times(1)).findAll();
+    String expectedJson = mapper.writeValueAsString(expectedRequests);
+    String responseString = response.getResponse().getContentAsString();
+    assertEquals(expectedJson, responseString);
+  }
+
+  @WithMockUser(roles = {"ADMIN", "USER"})
+  @Test
+  public void an_admin_user_can_post_a_new_recommendationrequest() throws Exception {
+    // arrange
+
+    LocalDateTime ldt1 = LocalDateTime.parse("2022-04-20T00:00:00");
+    LocalDateTime ldt2 = LocalDateTime.parse("2022-05-01T00:00:00");
+
+    RecommendationRequest recommendationRequest1 =
+        RecommendationRequest.builder()
+            .requesterEmail("cgaucho@ucsb.edu")
+            .professorEmail("phtcon@ucsb.edu")
+            .explanation("BS/MS program")
+            .dateRequested(ldt1)
+            .dateNeeded(ldt2)
+            .done(true)
+            .build();
+
+    when(recommendationRequestRepository.save(eq(recommendationRequest1)))
+        .thenReturn(recommendationRequest1);
+
+    // act
+    MvcResult response =
+        mockMvc
+            .perform(
+                post("/api/RecommendationRequest/post")
+                    .param("requesterEmail", "cgaucho@ucsb.edu")
+                    .param("professorEmail", "phtcon@ucsb.edu")
+                    .param("explanation", "BS/MS program")
+                    .param("dateRequested", "2022-04-20T00:00:00")
+                    .param("dateNeeded", "2022-05-01T00:00:00")
+                    .param("done", "true")
+                    .with(csrf()))
+            .andExpect(status().isOk())
+            .andReturn();
+
+    // assert
+    verify(recommendationRequestRepository, times(1)).save(recommendationRequest1);
+    String expectedJson = mapper.writeValueAsString(recommendationRequest1);
+    String responseString = response.getResponse().getContentAsString();
+    assertEquals(expectedJson, responseString);
+  }
+}


### PR DESCRIPTION
Closes #21 

Adds the GET /api/RecommendationRequest/all and POST /api/RecommendationRequest/post endpoints.

Created the controller class RecommendationRequestController.java with the two endpoints. GET requires ROLE_USER and POST requires ROLE_ADMIN.

Created the test file RecommendationRequestControllerTests.java with 6 tests covering authorization and database actions.

Verified 100 percent line coverage with Jacoco and 100 percent mutation coverage with Pitest. Tested the endpoints work on localhost via Swagger and on the Dokku dev deployment.

Dev deployment link: https://team01-dev-f1amek1ller.dokku-15.cs.ucsb.edu